### PR TITLE
Write State Tree Test Small refactor Marketplace Screen

### DIFF
--- a/test/coupon_marketplace/interface/state_tree_test.exs
+++ b/test/coupon_marketplace/interface/state_tree_test.exs
@@ -1,0 +1,16 @@
+defmodule CouponMarketplace.Interface.StateTreeTest do
+  use ExUnit.Case
+  alias CouponMarketplace.Interface.StateTree
+
+  describe "read and write" do
+    test "they read and write to the genserver" do
+      start_supervised!({StateTree, [%{}]})
+
+      assert StateTree.read() == %{}
+
+      StateTree.write(%{screen: :login})
+
+      assert StateTree.read() == %{screen: :login}
+    end
+  end
+end


### PR DESCRIPTION
Instead of calculating the difference between the
buyer balance and coupon value twice it is now done
once to reduce a possibility for the state to be
different from the database.

-	modified:   lib/coupon_marketplace/screens/marketplace.ex
-	new file:   test/coupon_marketplace/interface/state_tree_test.exs